### PR TITLE
[ fix ] Sync version with Git tag (0.2.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-server-mule",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Rescript library for hauling language servers from your disk or somewhere else",
   "main": "Main.bs.js",
   "scripts": {


### PR DESCRIPTION
The version was out of sync from the git tag. This caused `agda-mode-vscode` to error when language server is enabled https://github.com/banacorn/agda-mode-vscode/issues/116.

After this is merged, the dependency version in `agda-mode-vscode` should be updated to `0.2.4`: https://github.com/banacorn/agda-mode-vscode/blob/905ec6189976b98f6806d73c735c9602c0f39bda/package.json#L48. I created a PR for that: https://github.com/banacorn/agda-mode-vscode/pull/126.